### PR TITLE
Fix reload function

### DIFF
--- a/app/src/main/java/com/example/groupdrive/ui/adapters/recyclerAdapter.java
+++ b/app/src/main/java/com/example/groupdrive/ui/adapters/recyclerAdapter.java
@@ -79,7 +79,7 @@ public class recyclerAdapter extends RecyclerView.Adapter<recyclerAdapter.MyView
         ApiInterface apiInterface = ApiClient.getApiClient().create(ApiInterface.class);
         Call<ArrayList<Trip>> call;
         Response<ArrayList<Trip>> response;
-        call = apiInterface.getTrips("");
+        call = apiInterface.getTrips(null);
         try {
             response = call.execute();
         } catch (IOException e) {


### PR DESCRIPTION
Send null for the getTrip api call, so the filter will
return all trips on reload.