### PR TITLE
Hide status bar on maps activity

### DIFF
--- a/app/src/main/java/com/example/groupdrive/ui/fragments/MapsActivity.java
+++ b/app/src/main/java/com/example/groupdrive/ui/fragments/MapsActivity.java
@@ -146,6 +146,7 @@ public class MapsActivity extends AppCompatActivity implements OnMapReadyCallbac
         super.onCreate(savedInstanceState);
         binding = ActivityMapsBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+        getSupportActionBar().hide();
         markers = new ArrayList<>();
         StrictMode.ThreadPolicy policy = new StrictMode.ThreadPolicy.Builder().permitAll().build();
         StrictMode.setThreadPolicy(policy);

--- a/app/src/main/java/com/example/groupdrive/ui/fragments/ViewTripDetails.java
+++ b/app/src/main/java/com/example/groupdrive/ui/fragments/ViewTripDetails.java
@@ -16,6 +16,7 @@ public class ViewTripDetails extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_view_trip_details);
+        getSupportActionBar().hide();
         TextView title_tv = findViewById(R.id.details_trip_title);
         TextView description_tv = findViewById(R.id.details_trip_desc);
         TextView date_tv = findViewById(R.id.details_trip_date);


### PR DESCRIPTION
The status bar prints "GroupDrive" title and
hides part of the screen in mapsActivity.

This commit adds:
"getSupportActionBar().hide();"
to the onCreate function to make it disappear.