### PR TITLE
Add default trip name

### DIFF
--- a/app/src/main/java/com/example/groupdrive/ui/fragments/MakerActivity.java
+++ b/app/src/main/java/com/example/groupdrive/ui/fragments/MakerActivity.java
@@ -77,6 +77,9 @@ public class MakerActivity extends AppCompatActivity {
                 return;
             }
         }
+        if (title.equals("")) {
+            title = username+"'s trip";
+        }
         Trip newTrip = new Trip(tripID, username, title, description, dateTime, meetingPoint, meetingPointWazeUrl,groupSizeLimit,false);
 
         Call<Trip> call;


### PR DESCRIPTION
When a user creates a trip with an empty title,
the trip will get the default name: "{username}'s trip", (like "lior's trip")